### PR TITLE
Closes caffeinated/widgets#3

### DIFF
--- a/src/WidgetFactory.php
+++ b/src/WidgetFactory.php
@@ -68,9 +68,11 @@ class WidgetFactory
 	{
 		$flattened = array();
 
-		array_walk_recursive($parameters, function($value, $key) use (&$flattened) {
-			$flattened[$key] = $value;
-		});
+		foreach($parameters as $parameter) {
+			array_walk($parameter, function($value, $key) use (&$flattened) {
+				$flattened[$key] = $value;
+			});
+		}
 
 		return $flattened;
 	}


### PR DESCRIPTION
This will allow to pass arrays as parameter like this :

```
{!! Widget::MyWidget(['items' => ['key1' => 'value1', 'key2' => 'value2']]) !!}
```

$parameters equal the parameters passed to the widget. The first key is always numeric, this is why the foreach is needed.

With this modification you can already pass multiple arrays, for example : 

```
{!! Widget::MyWidget(['array1' => ['key1' => 'value1']], ['array2' => ['key1' => 'value1']]) !!}
```

or 

```
{!! Widget::MyWidget(['array1' => ['key1' => 'value1'], 'array2' => ['key1' => 'value1']]) !!}
```

In these examples, you can access parameters in the widget with $this->array1 and $this->array2.
